### PR TITLE
Minor fixes

### DIFF
--- a/src/app/seamly2d/dialogs/export_layout_dialog.cpp
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.cpp
@@ -763,7 +763,7 @@ void ExportLayoutDialog::writeSettings() const
  */
 QString ExportLayoutDialog::modeString() const
 {
-    QString modeStr = QStringLiteral("");
+    QString modeStr = QStringLiteral();
     if (qApp->Seamly2DSettings()->useModeType())
     {
         switch (m_mode)

--- a/src/app/seamly2d/dialogs/export_layout_dialog.cpp
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.cpp
@@ -763,7 +763,7 @@ void ExportLayoutDialog::writeSettings() const
  */
 QString ExportLayoutDialog::modeString() const
 {
-    QString modeStr = QStringLiteral();
+    QString modeStr = QStringLiteral("");
     if (qApp->Seamly2DSettings()->useModeType())
     {
         switch (m_mode)

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -64,7 +64,6 @@
 #include <QString>
 
 #include "../vmisc/diagnostic.h"
-#include "qobject.h"
 
 const QString CustomMSign    = QStringLiteral("@");
 const QString CustomIncrSign = QStringLiteral("#");

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -64,6 +64,7 @@
 #include <QString>
 
 #include "../vmisc/diagnostic.h"
+#include "qobject.h"
 
 const QString CustomMSign    = QStringLiteral("@");
 const QString CustomIncrSign = QStringLiteral("#");


### PR DESCRIPTION
- Include `<qobject.h>` in `ifcdef.cpp` library source file
- Add emtpy string literal in object declaration of QStringLiteral to clear warning