### PR TITLE
Fix Qt6 version freeze on file open

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -463,7 +463,7 @@ QSharedPointer<VMeasurements> MainWindow::OpenMeasurementFile(const QString &pat
 
         CheckRequiredMeasurements(measurements.data());
 
-        if (measurements->Type() == MeasurementsType::Multisize)
+        if (measurements.data()->Type() == MeasurementsType::Multisize)
         {
             if (measurements->MUnit() == Unit::Inch)
             {


### PR DESCRIPTION
Version:
- Windows 10
- Qt6.5.3
- MSVC19

Description:
Qt6 version used to freeze when opening a file after Qt5 version of the project was ran. One fix was to have a separete settings file in `AppData\Roaming`. This however was a hacky fix. When inspecting the Qt6 version with a debugger the code commited threw an execption and terminted the thread it was running on. This fix, doesn't throw an exception and fixes the freeze issue with the Qt6 version.

Tested:
- Deleted settings folder in `AppData\Roaming`
- Run Qt5 project and opened .val file from Qt6 project
- Stopped Qt5
- Run Qt6 project and open .val file from same Qt6 project examples folder